### PR TITLE
Fix bug #3 and add corresponding test case

### DIFF
--- a/FSharpLu.Json/FSharpLu.Json.fsproj
+++ b/FSharpLu.Json/FSharpLu.Json.fsproj
@@ -60,6 +60,8 @@
     <Content Include="packages.config" />
     <None Include="FSharpLu.Json.nuspec" />
     <None Include="Script.fsx" />
+    <None Include="Scripts\load-references-release.fsx" />
+    <None Include="Scripts\load-project-release.fsx" />
   </ItemGroup>
   <ItemGroup>
     <Reference Include="mscorlib" />

--- a/FSharpLu.Json/Script.fsx
+++ b/FSharpLu.Json/Script.fsx
@@ -12,8 +12,8 @@ open Microsoft.FSharpLu.Json
 type WithFields = SomeField of int * int
 type ComplexDu = ComplexDu of WithFields | SimpleDU | AString of string
 let x= (ComplexDu (SomeField (4,9))) |> Default.serialize
-let y = x |> Default.deserialize :> ComplexDu 
-let z = x |> Compact.deserialize :> ComplexDu
+let y = x |> Default.deserialize<ComplexDu>
+let z = x |> Compact.deserialize<ComplexDu>
 
 module T =
     type OptionOfBase = int option
@@ -22,3 +22,19 @@ module T =
     Some 5 |> Default.serialize |> BackwardCompatible.deserialize :> OptionOfBase 
     Default.deserialize<OptionOfBase> "null"
     BackwardCompatible.deserialize<OptionOfBase> "null"
+
+module T2  =
+    type X = {Some :string}
+    
+    Option.Some { X.Some = "test"} |> Compact.serialize
+
+    Option.Some { X.Some = null} |> Compact.serialize
+
+    let z = Option.Some { X.Some = null} |> Compact.serialize |> Compact.deserialize<X option>
+    
+    Some (Some null) |> Compact.serialize<obj option option> |> Compact.deserialize<obj option option>
+
+    Some null |> Compact.serialize<obj option> |> Compact.deserialize<obj option>
+
+    null  |> Compact.serialize|> Compact.deserialize<obj option option>
+

--- a/FSharpLu.Json/Scripts/load-project-release.fsx
+++ b/FSharpLu.Json/Scripts/load-project-release.fsx
@@ -1,0 +1,9 @@
+// Warning: generated file; your changes could be lost when a new file is generated.
+#I __SOURCE_DIRECTORY__
+#load "load-references-release.fsx"
+#load "../AssemblyInfo.fs"
+      "../Helpers.fs"
+      "../WithFunctor.fs"
+      "../NewtonSoft.fs"
+      "../Compact.fs"
+      "../BackwardCompatible.fs"

--- a/FSharpLu.Json/Scripts/load-references-release.fsx
+++ b/FSharpLu.Json/Scripts/load-references-release.fsx
@@ -1,0 +1,5 @@
+// Warning: generated file; your changes could be lost when a new file is generated.
+#I __SOURCE_DIRECTORY__
+#r "../../packages/Newtonsoft.Json.8.0.3/lib/net45/Newtonsoft.Json.dll"
+#r "System.Core.dll"
+#r "System.dll"

--- a/FSharpLu.Tests/JsonTests.fs
+++ b/FSharpLu.Tests/JsonTests.fs
@@ -19,6 +19,9 @@ type 'a NestedOptions = 'a option option option option
 
 type 'a Ambiguous = { Some : 'a }
 
+type NestedStructure = { subField : int }
+type NestedOptionStructure = { field : NestedStructure option }
+
 let inline serialize< ^T> (x: ^T) = Compact.serialize< ^T> x
 let inline deserialize< ^T> x : ^T = Compact.deserialize< ^T> x
 
@@ -84,6 +87,8 @@ type Reciprocality () =
     static member x19 = reciprocal<int NestedOptions>
     static member x20 = reciprocal<Ambiguous<string>>
     static member x21 = reciprocal<Ambiguous<SimpleDu>>
+    static member x22 = reciprocal<NestedOptionStructure>
+    
 
 type CoincidesWithJsonNetOnDeserialization () =
     static member x1 = coincidesWithDefault<ComplexDu>
@@ -107,6 +112,7 @@ type CoincidesWithJsonNetOnDeserialization () =
     static member x19 = coincidesWithDefault<int NestedOptions>
     static member x20 = coincidesWithDefault<Ambiguous<string>>
     static member x21 = coincidesWithDefault<Ambiguous<SimpleDu>>
+    static member x22 = coincidesWithDefault<NestedOptionStructure>
 
 type BackwardCompatibility () =
     static member x1 = backwardCompatibleWithDefault<ComplexDu>
@@ -130,7 +136,7 @@ type BackwardCompatibility () =
     static member x19 = backwardCompatibleWithDefault<int NestedOptions>
     static member x20 = backwardCompatibleWithDefault<Ambiguous<string>>
     static member x21 = backwardCompatibleWithDefault<Ambiguous<SimpleDu>>
-
+    static member x22 = backwardCompatibleWithDefault<NestedOptionStructure>
 
 [<TestClass>]
 type JsonSerializerTests() =

--- a/FSharpLu.Tests/JsonTests.fs
+++ b/FSharpLu.Tests/JsonTests.fs
@@ -42,9 +42,9 @@ let inline reciprocal< ^T when ^T:equality> (x: ^T) =
 let inline areReciprocal< ^T when ^T:equality> (x: ^T) = 
     let s = x |> serialize< ^T>
     let sds = s |> deserialize< ^T> |> serialize< ^T>
-    Assert.AreEqual(s, sds, sprintf "Inconsistent serialization: 1st call: <%s> 2nd call <%s>" s sds)
+    Assert.AreEqual(s, sds, sprintf "Inconsistent serialization: 1st call: <%s> 2nd call <%s>. Type %A" s sds (typeof< ^T>))
     let sdsd = sds |> deserialize< ^T>
-    Assert.AreEqual(sdsd, x, sprintf "Did not get the same object back: <%A> gave <%A>" x sdsd)
+    Assert.AreEqual(sdsd, x, sprintf "Did not get the same object back: <%A> gave back <%A> for type %A" x sdsd (typeof< ^T>))
 
 /// Check that given object serializes to the specified Json string
 let inline serializedAs json o = 


### PR DESCRIPTION
This is a quick fix for #2. 
This change enables the Json.Net `MissingMemberHandling` option which makes the Compact deserializer strict. This means that deserialization will faill if there is any member in the Json that is not present in the F# type. This is not technically required for Compact deserialization but it is needed to make the current implementation of the BackwardConmpatible serializer pass all the unit tests. In particular without this setting the following code
```
type NestedStructure = { subField : int}
type NestedOptionStructure = NestedStructure option 

let x= Some {subField = 456 }
let z= Default.serialize x 
z|> Compact.deserialize<NestedOptionStructure>
```
would deserialize to `Some {subField = 0;}` instead of throwing, which would then confuse the backward-compatible deserializer.