### PR TITLE
Fix Json.Net incompatibility with F# 4.1 #14

### DIFF
--- a/FSharpLu.Json/FSharpLu.Json.fsproj
+++ b/FSharpLu.Json/FSharpLu.Json.fsproj
@@ -69,8 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />

--- a/FSharpLu.Json/packages.config
+++ b/FSharpLu.Json/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.1" targetFramework="net452" />
 </packages>

--- a/FSharpLu.Tests/App.config
+++ b/FSharpLu.Tests/App.config
@@ -4,11 +4,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="FSharp.Core" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.4.0.0" newVersion="4.4.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.4.1.0" newVersion="4.4.1.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="10.0.1.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/FSharpLu.Tests/FSharpLu.Tests.fsproj
+++ b/FSharpLu.Tests/FSharpLu.Tests.fsproj
@@ -71,8 +71,7 @@
     <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
     <Reference Include="mscorlib" />
     <Reference Include="Newtonsoft.Json">
-      <HintPath>..\packages\Newtonsoft.Json.8.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
-      <Private>True</Private>
+      <HintPath>..\packages\Newtonsoft.Json.10.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -83,7 +82,7 @@
       <Private>True</Private>
     </ProjectReference>
   </ItemGroup>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
   </Target>

--- a/FSharpLu.Tests/packages.config
+++ b/FSharpLu.Tests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FsCheck" version="2.4.0" targetFramework="net452" />
-  <package id="Newtonsoft.Json" version="8.0.3" targetFramework="net452" />
+  <package id="Newtonsoft.Json" version="10.0.1-beta1" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
- Fix FsCheck by bumping up F# version number in app.config for the unit test project
- Upgrade to Json.NET 10.0.1 which fixes the incompatibility with F# 4.1 (https://github.com/JamesNK/Newtonsoft.Json/issues/1180)