### PR TITLE
added precomputing of type information to speed up serialisation sign…

### DIFF
--- a/FSharpLu.Json/Compact.fs
+++ b/FSharpLu.Json/Compact.fs
@@ -69,11 +69,9 @@ type CompactUnionJsonConverter() =
         memorise 
             (fun objectType ->        
                 // Include F# discriminated unions
-                let result = 
-                    FSharpType.IsUnion objectType
-                    // and exclude the standard FSharp lists (which are implemented as discriminated unions)
-                    && not (objectType.GetTypeInfo().IsGenericType && objectType.GetGenericTypeDefinition() = typedefof<_ list>)
-                result)
+                FSharpType.IsUnion objectType
+                // and exclude the standard FSharp lists (which are implemented as discriminated unions)
+                && not (objectType.GetTypeInfo().IsGenericType && objectType.GetGenericTypeDefinition() = typedefof<_ list>))
 
     override __.CanConvert(objectType:System.Type) = canConvertMemorised objectType
 


### PR DESCRIPTION
Was using your library to do some JSON serialisation and while it's nice I found some performance issues with it mainly around the heavy use of reflection in the serialisation step. The fact is however a lot of this only needs to be done per type (not for every item being serialised).

These changes improved my serialization performance significantly (approximately a 4x factor) but your mileage may vary. Created a synthetic benchmark test quickly:

    New Solution [Batch Size: 500000, Time in Milliseconds: 71586, 15.9MB Usage during test]
    Current FSharpLu.Json [Batch Size: 500000, Time in Milliseconds: 208828, 15.9MB Usage during test]
    Using delegate for option [Batch Size: 500000, Time in Milliseconds: 93371-94000] with delegate for option (Didn't observe RAM of process)

So a 2.9x speedup approx on the benchmark above. Based on the above I've reverted using the delegate for the option serialisation code and optimised the pre-existing codebase. Didn't observe any RAM increase really in all three tests (just checked Task Manager unscientifically). The space requirement should go up with the amount of types you plan to serialise in your application but with just the few types in my test it wasn't noticeable.

Example type I was using to test:

```
type TestUnion = 
    | OptionOne of int
    | OptionTwo of string

type TestType = {
    FieldOne: string
    FieldTwo: int
    FieldThree: int option
    FieldFour: TestUnion
    FieldFive: string option option
    FieldSix: TestUnion option
}

```