### PR TITLE
Package nuget in Appveyor and meet Microsoft nuget policy

### DIFF
--- a/FSharpLu.Json/FSharpLu.Json.fsproj
+++ b/FSharpLu.Json/FSharpLu.Json.fsproj
@@ -32,7 +32,7 @@
     <DefineConstants>DEBUG;TRACE;$(CompilationSymbols)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>

--- a/FSharpLu.Json/FSharpLu.Json.fsproj
+++ b/FSharpLu.Json/FSharpLu.Json.fsproj
@@ -3,11 +3,11 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard1.6;netstandard2.0;net452;net461</TargetFrameworks>
     <PackageId>Microsoft.FSharpLu.Json</PackageId>
-    <Authors>william.blum@microsoft.com</Authors>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Product>Microsoft.FSharpLu.Json</Product>
     <Description>Json serialization converters for F# option types and discriminated unions.</Description>
-    <Copyright>Copyright Microsoft</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>F#, FSharp, Utilities, Json, discriminated unions</PackageTags>
     <PackageReleaseNotes>Port project to .NET Core</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Microsoft/fsharplu</PackageProjectUrl>

--- a/FSharpLu.Windows/FSharpLu.Windows.fsproj
+++ b/FSharpLu.Windows/FSharpLu.Windows.fsproj
@@ -4,11 +4,11 @@
     <!-- This assembly does not target .net standard (either 1.6 or 2.0) due to missing APIs -->
     <TargetFrameworks>net452;net461</TargetFrameworks>
     <PackageId>Microsoft.FSharpLu.Windows</PackageId>
-    <Authors>william.blum@microsoft.com</Authors>
+    <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
     <Product>Microsoft.FSharpLu.Windows</Product>
     <Description>Windows specific helpers requiring the full .NetFramework</Description>
-    <Copyright>Copyright Microsoft</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>F#, FSharp, Utilities, Windows, Security, Console</PackageTags>
     <PackageReleaseNotes>Port project to .NET Core</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Microsoft/fsharplu</PackageProjectUrl>
@@ -45,7 +45,7 @@
     <Compile Include="Security.fs" />
     <Compile Include="TraceLoggingConsole.fs" />
   </ItemGroup>
- 
+
  <ItemGroup>
    <ProjectReference Include="..\FSharpLu\FSharpLu.fsproj" />
  </ItemGroup>

--- a/FSharpLu.Windows/FSharpLu.Windows.fsproj
+++ b/FSharpLu.Windows/FSharpLu.Windows.fsproj
@@ -33,7 +33,7 @@
     <DefineConstants>DEBUG;TRACE;$(CompilationSymbols)</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <DebugSymbols>true</DebugSymbols>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>

--- a/FSharpLu/FSharpLu.fsproj
+++ b/FSharpLu/FSharpLu.fsproj
@@ -2,11 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452;net461</TargetFrameworks>
-    <Authors>william.blum@microsoft.com</Authors>
+    <Authors>Microsoft</Authors>
     <PackageProjectUrl>https://github.com/Microsoft/fsharplu</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/fsharplu/blob/master/LICENSE.MD</PackageLicenseUrl>
     <Description>Utilities and .Net library wrappers for F#</Description>
-    <Copyright>Copyright Microsoft</Copyright>
+    <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>F#, FSharp, FSharp utilities, collection, logging, diagnostic, async, Json</PackageTags>
     <PackageReleaseNotes>Port projects to .Net core</PackageReleaseNotes>
     <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
@@ -85,7 +85,7 @@
     <PackageReference Include="System.Collections.NonGeneric" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal" Version="4.3.0" />
     <PackageReference Include="System.Security.Principal.Windows" Version="4.4.0" />
-    <PackageReference Include="System.Security.Permissions" Version="4.4.0" />   
+    <PackageReference Include="System.Security.Permissions" Version="4.4.0" />
  </ItemGroup>
 
 </Project>

--- a/FSharpLu/FSharpLu.fsproj
+++ b/FSharpLu/FSharpLu.fsproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net452;net461</TargetFrameworks>
@@ -21,6 +21,7 @@
     <AssemblyName>Microsoft.FSharpLu</AssemblyName>
   </PropertyGroup>
 
+
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
@@ -30,7 +31,7 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
-    <DebugType>pdbonly</DebugType>
+    <DebugType>portable</DebugType>
     <Optimize>true</Optimize>
     <Tailcalls>true</Tailcalls>
     <DefineConstants>TRACE;$(CompilationSymbols)</DefineConstants>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,45 @@
+version: 0.10.{build}
+pull_requests:
+  do_not_increment_build_number: true
+image: Visual Studio 2017
+configuration:
+- Debug
+- Release
+platform: Any CPU
+before_build:
+- cmd: nuget restore
+- ps: >-
+    nuget restore
+
+    .\scripts\Update-AssemblyVersion.ps1 -version $Env:APPVEYOR_BUILD_VERSION
+build:
+  verbosity: minimal
+after_build:
+- ps: .\scripts\packnuget.ps1 -pack -configuration $Env:CONFIGURATION -version $Env:APPVEYOR_BUILD_VERSION
+artifacts:
+  - path: FSharpLu.Json\bin\Debug\
+    name: FSharpLu.Json-Debug
+  - path: FSharpLu.Json\bin\Release\
+    name: FSharpLu.Json-Release
+  - path: FSharpLu\bin\Debug\
+    name: FSharpLu-Debug
+  - path: FSharpLu\bin\Release\
+    name: FSharpLu-Release
+  - path: '**\*.nupkg'
+    name: FSharpLu-Nuget-Packages
+    type: NuGetPackage
+
+# Deployment commented out: instead of auto-releasing to nuget
+# deployment to nuget is done manually using AppVeyor environments.
+# Configuraiton used is left here for reference:
+
+# We publish to Nuget only if building release configuration and
+# for master branch
+#deploy:
+#- provider: NuGet
+#  on:
+#    branch: master
+#    configuration: release
+#  api_key:
+#    secure: ARiE9w5iTpnkxiW6ybXq7KCD9Af7SkMmKEP/CRJZJ2eqsEvjWYrVaBMfZF5EzKWX
+#  artifact: FSharpLu-Nuget-Packages

--- a/scripts/packnuget.ps1
+++ b/scripts/packnuget.ps1
@@ -27,7 +27,7 @@ param(
 
 $ErrorActionPreference = 'stop'
 $root = Split-Path -parent $PsScriptRoot
-$outputDir = "$root\nugetouput"
+$outputDir = "$root\nugetoutput"
 
 Push-Location $root
 
@@ -87,11 +87,11 @@ Before proceeding please make sure to manually place the signed assemblies under
 
     Write-Host "Packing nuget packages"
     # NOTE: Using --include-symbols to include symbols in Nuget package does not work due to a bug with
-    # `dotnet build` where the symbol files gets automatically deleted when the build completes. 
+    # `dotnet build` where the symbol files gets automatically deleted when the build completes.
     # There is no known workaround for now.
-    dotnet pack -o $outputDir /p:PackageVersion="$version" /p:Configuration=$configuration --no-build $root\FSharpLu\FSharpLu.fsproj 
-    dotnet pack -o $outputDir /p:PackageVersion="$version" /p:Configuration=$configuration --no-build $root\FSharpLu.Json\FSharpLu.Json.fsproj 
-    dotnet pack -o $outputDir /p:PackageVersion="$version" /p:Configuration=$configuration --no-build $root\FSharpLu.Windows\FSharpLu.Windows.fsproj 
+    dotnet pack -o $outputDir /p:PackageVersion="$version" /p:Configuration=$configuration /p:Platform="AnyCPU" --no-build $root\FSharpLu\FSharpLu.fsproj
+    dotnet pack -o $outputDir /p:PackageVersion="$version" /p:Configuration=$configuration /p:Platform="AnyCPU" --no-build $root\FSharpLu.Json\FSharpLu.Json.fsproj
+    dotnet pack -o $outputDir /p:PackageVersion="$version" /p:Configuration=$configuration /p:Platform="AnyCPU" --no-build $root\FSharpLu.Windows\FSharpLu.Windows.fsproj
 
     if ($push) {
         pushLatest 'Microsoft.FSharpLu'


### PR DESCRIPTION
- Add AppVeyor yaml to project
- Fix PDB symbols were not included when dotnet building at the command-line in release mode