### PR TITLE
use property name resolver in compact union converter

### DIFF
--- a/FSharpLu.Json/Compact.fs
+++ b/FSharpLu.Json/Compact.fs
@@ -21,10 +21,6 @@ module private ConverterHelpers =
         // Item1, Item2, etc. excluding Items[n] indexer. Valid only on tuple types.
         (prop.Name.StartsWith("Item") || prop.Name = "Rest") && (Seq.isEmpty <| prop.GetIndexParameters())
 
-    let inline toCamel (name:string) =
-        if System.Char.IsLower (name, 0) then name
-        else string(System.Char.ToLower name.[0]) + name.Substring(1)
-
 module Memorised = 
     let inline memorise (f: 'key -> 'result) =
         let d = ConcurrentDictionary<'key, 'result>()
@@ -103,7 +99,7 @@ type CompactUnionJsonConverter(?tupleAsHeterogeneousArray:bool) =
 
         let convertName =
             match serializer.ContractResolver with
-            | :? CamelCasePropertyNamesContractResolver -> toCamel
+            | :? DefaultContractResolver as resolver -> resolver.GetResolvedPropertyName
             | _ -> id
 
         // Option type?

--- a/FSharpLu.Tests/JsonTests.fs
+++ b/FSharpLu.Tests/JsonTests.fs
@@ -17,6 +17,8 @@ type 'a Tree = Leaf of 'a | Node of 'a Tree * 'a Tree
 type 'a Test = Case1 | Case2 of int | Case3 of int * string * 'a
 type MapType = Map<string,Color>
 type 'a NestedOptions = 'a option option option option
+type ConsecutiveUppercaseRecord = { BAR : int ; BAZNumber : int }
+type ConsecutiveUppercaseDu = FOO | FOOWithRecord of ConsecutiveUppercaseRecord
 
 type 'a Wrapper = { WrappedField : 'a }
 type NestedStructure = { subField : int }
@@ -323,6 +325,13 @@ type JsonSerializerTests() =
         let du = ComplexDu <| SomeField (2, 3)
         let str = CamelCaseSerializer.serialize du
         Assert.AreEqual("""{"complexDu":{"someField":[2,3]}}""", str)
+
+    [<TestMethod>]
+    [<TestCategory("FSharpLu.Json.CamelCase")>]
+    member __.``CamelCaseSerializer handles discriminated unions with consecutive uppercase characters`` () =
+        let du = [ FOO ; FOOWithRecord { BAR=2; BAZNumber=3 } ]
+        let str = CamelCaseSerializer.serialize du
+        Assert.AreEqual("""["foo",{"fooWithRecord":{"bar":2,"bazNumber":3}}]""", str)
 
     [<TestMethod>]
     [<TestCategory("FSharpLu.Json.CamelCase")>]


### PR DESCRIPTION
fixes #49 by converting case names with the property name resolver