### PR TITLE
Color console logger targetting netstandard2.0

### DIFF
--- a/CI-vsts.yml
+++ b/CI-vsts.yml
@@ -1,11 +1,10 @@
 ## VSTS pipeline to build, test, package and sign the nuget package
 
 queue:
-  name: sf-pool
   demands: vstest
 
 variables:
-  NUGET_PACKAGE_VERSION: 0.10.28
+  NUGET_PACKAGE_VERSION: 0.10.29
 
 #Your build definition references the ‘NUGET_PACKAGE_VERSION’ variable, which you’ve selected to be settable at queue time. Create or edit the build definition for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971
 #Your build definition references the ‘BuildConfiguration’ variable, which you’ve selected to be settable at queue time. Create or edit the build definition for this YAML file, define the variable on the Variables tab, and then select the option to make it settable at queue time. See https://go.microsoft.com/fwlink/?linkid=865971

--- a/FSharpLu.Windows.Sample.fsproj/FSharpLu.Windows.Sample.fsproj
+++ b/FSharpLu.Windows.Sample.fsproj/FSharpLu.Windows.Sample.fsproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="Program.fs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Update="FSharp.Core" Version="4.5.4" />
+    <ProjectReference Include="..\FSharpLu.Windows\FSharpLu.Windows.fsproj" />
+    <ProjectReference Include="..\FSharpLu\FSharpLu.fsproj" />
+  </ItemGroup>
+
+</Project>

--- a/FSharpLu.Windows.Sample.fsproj/Program.fs
+++ b/FSharpLu.Windows.Sample.fsproj/Program.fs
@@ -1,0 +1,11 @@
+﻿open Microsoft.FSharpLu.Logging
+
+[<EntryPoint>]
+let main argv =
+    printfn "Hello World from F#!"
+    use logger = System.Diagnostics.Listener.registerFileAndConsoleTracer "myComponentName" None
+    Trace.info "Information: Number of arguments %d" argv.Length
+    Trace.error "Printing an error"
+    Trace.warning "Printing a warning"
+
+    0 

--- a/FSharpLu.Windows/FSharpLu.Windows.fsproj
+++ b/FSharpLu.Windows/FSharpLu.Windows.fsproj
@@ -1,8 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <!-- This assembly does not target .net standard (either 1.6 or 2.0) due to missing APIs -->
-    <TargetFrameworks>net452;net461;net462;net472</TargetFrameworks>
+    <TargetFrameworks>net452;net461;net462;net472;netstandard2.0</TargetFrameworks>
     <PackageId>Microsoft.FSharpLu.Windows</PackageId>
     <Authors>Microsoft</Authors>
     <Company>Microsoft</Company>
@@ -10,7 +9,7 @@
     <Description>Windows specific helpers requiring the full .NetFramework</Description>
     <Copyright>© Microsoft Corporation. All rights reserved.</Copyright>
     <PackageTags>F#, FSharp, Utilities, Windows, Security, Console</PackageTags>
-    <PackageReleaseNotes>Signed assemblies and nuget package</PackageReleaseNotes>
+    <PackageReleaseNotes>Add netstandard2.0 target</PackageReleaseNotes>
     <PackageProjectUrl>https://github.com/Microsoft/fsharplu</PackageProjectUrl>
     <PackageLicenseUrl>https://github.com/Microsoft/fsharplu/blob/master/LICENSE.MD</PackageLicenseUrl>
     <RepositoryUrl>https://github.com/Microsoft/fsharplu/</RepositoryUrl>

--- a/FSharpLu.Windows/Security.fs
+++ b/FSharpLu.Windows/Security.fs
@@ -70,8 +70,12 @@ let public impersonate (log:Logger.Logger<_,_>) logonType alias domain getPwd f 
     log.write "Impersonating %s\%s from %s" domain alias (WindowsIdentity.GetCurrent().Name)
     use newId = new WindowsIdentity(safeTokenHandle.DangerousGetHandle())
     let result =
+#if NET452 || NET461 || NET462 || NET472
         (use impersonatedUser = newId.Impersonate()
         f())
+#else
+        WindowsIdentity.RunImpersonated(newId.AccessToken, fun () -> f ())
+#endif
     log.write "Reimpersonated as %s" (WindowsIdentity.GetCurrent().Name)
     result
 

--- a/FSharpLu.Windows/TraceLoggingConsole.fs
+++ b/FSharpLu.Windows/TraceLoggingConsole.fs
@@ -8,7 +8,7 @@ namespace System.Diagnostics
     /// A System.Diagnostics trace listener redirecting messages to
     /// the Console with nice colors for errors and warnings.
     type ColorConsoleTraceListener(foregroundColors :EventColoring, backgroundColors :EventColoring) as this =
-        inherit ConsoleTraceListener()
+        inherit TextWriterTraceListener(Console.Out)
 
         let shouldTraceEvent (eventType:TraceEventType) =
             let isEnabled (e: TraceEventType) = eventType &&& e <> enum<TraceEventType> 0

--- a/FSharpLu.sln
+++ b/FSharpLu.sln
@@ -9,7 +9,10 @@ Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharpLu.Tests", "FSharpLu.
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{1FF1118A-322F-4F49-AF9A-ED825DE70260}"
 	ProjectSection(SolutionItems) = preProject
+		.gitattributes = .gitattributes
 		.gitignore = .gitignore
+		appveyor.yml = appveyor.yml
+		CI-vsts.yml = CI-vsts.yml
 		FSharpLu.Json.md = FSharpLu.Json.md
 		LICENSE.MD = LICENSE.MD
 		msft-StrongName.pub = msft-StrongName.pub
@@ -33,7 +36,9 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Scripts", "Scripts", "{A76D
 		scripts\Update-AssemblyVersion.ps1 = scripts\Update-AssemblyVersion.ps1
 	EndProjectSection
 EndProject
-Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpLu.Windows", "FSharpLu.Windows\FSharpLu.Windows.fsproj", "{2E2CDF04-F40A-4A61-A15D-18C2451CCF6E}"
+Project("{6EC3EE1D-3C4E-46DD-8F32-0CC8E7565705}") = "FSharpLu.Windows", "FSharpLu.Windows\FSharpLu.Windows.fsproj", "{2E2CDF04-F40A-4A61-A15D-18C2451CCF6E}"
+EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "FSharpLu.Windows.Sample", "FSharpLu.Windows.Sample.fsproj\FSharpLu.Windows.Sample.fsproj", "{267983C8-9326-43C6-A581-DB3520B103D7}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -57,6 +62,10 @@ Global
 		{2E2CDF04-F40A-4A61-A15D-18C2451CCF6E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2E2CDF04-F40A-4A61-A15D-18C2451CCF6E}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2E2CDF04-F40A-4A61-A15D-18C2451CCF6E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{267983C8-9326-43C6-A581-DB3520B103D7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{267983C8-9326-43C6-A581-DB3520B103D7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{267983C8-9326-43C6-A581-DB3520B103D7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{267983C8-9326-43C6-A581-DB3520B103D7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/FSharpLu/TraceLogging.fs
+++ b/FSharpLu/TraceLogging.fs
@@ -201,7 +201,7 @@ namespace System.Diagnostics
             }
 
         /// Registers both a file tracer as well as an auxiliary tracer constructed from the specified parameters.
-        let inline registerFileAndAuxiliaryTracerWithConfiguration< ^T, ^C when ^T :> TraceListener > (loggerConstructor:LoggingConfiguration< ^C> -> ^T) (parameters:LoggingConfiguration< ^C>) =
+        let inline registerFileAndAuxiliaryTracerWithConfiguration< ^T, ^C when ^T :> TextWriterTraceListener > (loggerConstructor:LoggingConfiguration< ^C> -> ^T) (parameters:LoggingConfiguration< ^C>) =
             let fileLogger =
                 // Reuse existing auxiliary listener if one is already registered
                 let existingFileListener =

--- a/README.md
+++ b/README.md
@@ -18,7 +18,9 @@ Some of the provided utilities are just thin `let`-bindings wrappers around exis
 
 - F# compiler. See https://fsharp.org/use/Windows and https://fsharp.org/use/linux/
 
-- Install dotnet core SDK 2.0.0 or greater from https://dotnet.microsoft.com/download/visual-studio-sdks.
+- Install .NET Core SDK from https://dotnet.microsoft.com/download/visual-studio-sdks.
+    - .NET Core 2.2 SDK 
+    - .NET Core 3.0 SDK 
 
 - Install .NET Framework Developer Packs from https://www.microsoft.com/net/download/visual-studio-sdks 
 for the following versions of .NET:


### PR DESCRIPTION
- Port color console logger to netstandard2.0 to unable use on Linux with dotnetcore
- Port Windows impersonation to netstandard2.0
- Add a sample showing how to use the file/console logger from FSharpLu.Windows