### PR TITLE
Write field-less union case name without formatting

### DIFF
--- a/FSharpLu.Json/Compact.fs
+++ b/FSharpLu.Json/Compact.fs
@@ -75,11 +75,13 @@ open Memorised
 /// The default formatting used by Json.Net to serialize F# discriminated unions
 /// and Option types is too verbose. This module implements a more succinct serialization
 /// for those data types.
-type CompactUnionJsonConverter(?tupleAsHeterogeneousArray:bool) =
+type CompactUnionJsonConverter(?tupleAsHeterogeneousArray:bool, ?usePropertyFormatterForValues:bool) =
     inherit Newtonsoft.Json.JsonConverter()
 
     ///  By default tuples are serialized as heterogeneous arrays.
-    let tupleAsHeterogeneousArray = defaultArg tupleAsHeterogeneousArray true
+    let tupleAsHeterogeneousArray = defaultArg tupleAsHeterogeneousArray true   
+    ///  By default formatting is used for values
+    let usePropertyFormatterForValues = defaultArg usePropertyFormatterForValues true
     let canConvertMemorised =
         memorise
             (fun objectType ->
@@ -148,7 +150,8 @@ type CompactUnionJsonConverter(?tupleAsHeterogeneousArray:bool) =
 
             match fields with
             // Field-less union case
-            | [||] -> writer.WriteValue(convertName case.Name)
+            | [||] when usePropertyFormatterForValues -> writer.WriteValue(convertName case.Name)
+            | [||] when not usePropertyFormatterForValues -> writer.WriteValue(case.Name)
             // Case with single field
             | [|onefield|] ->
                 writer.WriteStartObject()

--- a/FSharpLu.Tests/JsonTests.fs
+++ b/FSharpLu.Tests/JsonTests.fs
@@ -19,6 +19,7 @@ type MapType = Map<string,Color>
 type 'a NestedOptions = 'a option option option option
 type ConsecutiveUppercaseRecord = { BAR : int ; BAZNumber : int }
 type ConsecutiveUppercaseDu = FOO | FOOWithRecord of ConsecutiveUppercaseRecord
+type RecordWithDU = { du: ComplexDu }
 
 type 'a Wrapper = { WrappedField : 'a }
 type NestedStructure = { subField : int }
@@ -91,7 +92,7 @@ type CamelCaseSettings =
                 NullValueHandling = NullValueHandling.Ignore,
                 MissingMemberHandling = MissingMemberHandling.Error,
                 ContractResolver = Serialization.CamelCasePropertyNamesContractResolver())
-        s.Converters.Add(CompactUnionJsonConverter(true))
+        s.Converters.Add(CompactUnionJsonConverter(true, false))
         s
     static member formatting = Formatting.None
 
@@ -343,14 +344,21 @@ type JsonSerializerTests() =
     member __.``CamelCaseSerializer handles discriminated unions with consecutive uppercase characters`` () =
         let du = [ FOO ; FOOWithRecord { BAR=2; BAZNumber=3 } ]
         let str = CamelCaseSerializer.serialize du
-        Assert.AreEqual("""["foo",{"fooWithRecord":{"bar":2,"bazNumber":3}}]""", str)
+        Assert.AreEqual("""["FOO",{"fooWithRecord":{"bar":2,"bazNumber":3}}]""", str)
+
+    [<TestMethod>]
+    [<TestCategory("FSharpLu.Json.CamelCase")>]
+    member __.``CamelCaseSerializer makes properties camelCase but not values`` () =
+        let du = [ AString "foo"; SimpleDU ]
+        let str = CamelCaseSerializer.serialize du
+        Assert.AreEqual("""[{"aString":"foo"},"SimpleDU"]""", str)
 
     [<TestMethod>]
     [<TestCategory("FSharpLu.Json.CamelCase")>]
     member __.``CamelCaseSerializer handles option type`` () =
         let du = { WrappedField = Some Red }
         let str = CamelCaseSerializer.serialize du
-        Assert.AreEqual("""{"wrappedField":"red"}""", str)
+        Assert.AreEqual("""{"wrappedField":"Red"}""", str)
 
     [<TestMethod>]
     [<TestCategory("FSharpLu.Json.Fuzzing")>]


### PR DESCRIPTION
Resolves #58 

Sorry about opening two PRs, got the wrong author in there accidentally.