### PR TITLE
Add serializeToStream function

### DIFF
--- a/FSharpLu.Json/BackwardCompatible.fs
+++ b/FSharpLu.Json/BackwardCompatible.fs
@@ -12,7 +12,7 @@ type BackwardCompatible =
     static member inline public serialize = Compact.serialize
 
     /// Serialize an object to Json with the specified converter and save the result to a file
-    static member inline public serializeToFile file (obj:^T) = Compact.serializeToFile
+    static member inline public serializeToFile = Compact.serializeToFile
 
     /// Try to deserialize json to an object of type ^T
     static member inline tryDeserialize< ^T > json =

--- a/FSharpLu.Json/BackwardCompatible.fs
+++ b/FSharpLu.Json/BackwardCompatible.fs
@@ -14,6 +14,9 @@ type BackwardCompatible =
     /// Serialize an object to Json with the specified converter and save the result to a file
     static member inline public serializeToFile = Compact.serializeToFile
 
+    /// Serialize an object to Json with the specified converter and write the result to a stream
+    static member inline public serializeToStream = Compact.serializeToStream
+
     /// Try to deserialize json to an object of type ^T
     static member inline tryDeserialize< ^T > json =
         Helpers.tryDeserializeWithBoth< ^T, string>

--- a/FSharpLu.Json/Compact.fs
+++ b/FSharpLu.Json/Compact.fs
@@ -357,6 +357,9 @@ module Compact =
     /// Serialize an object to Json with the specified converter and save the result to a file
     [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
     let inline serializeToFile< ^T> file obj = S.serializeToFile file obj
+    /// Serialize an object to Json with the specified converter and write the result to a stream
+    [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
+    let inline serializeToStream< ^T> stream obj = S.serializeToStream stream obj
     /// Try to deserialize json to an object of type ^T
     [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
     let inline tryDeserialize< ^T> json = S.tryDeserialize< ^T> json
@@ -396,6 +399,9 @@ module Compact =
         /// Serialize an object to Json with the specified converter and save the result to a file
         [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
         let inline serializeToFile< ^T> file obj = S.serializeToFile file obj
+        /// Serialize an object to Json with the specified converter and write the result to a stream
+        [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
+        let inline serializeToStream< ^T> stream obj = S.serializeToStream stream obj
         /// Try to deserialize json to an object of type ^T
         [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
         let inline tryDeserialize< ^T> json = S.tryDeserialize< ^T> json
@@ -450,6 +456,9 @@ module Compact =
         /// Serialize an object to Json with the specified converter and save the result to a file
         [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
         let inline serializeToFile< ^T> file obj = S.serializeToFile file obj
+        /// Serialize an object to Json with the specified converter and write the result to a stream
+        [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
+        let inline serializeToStream< ^T> stream obj = S.serializeToStream stream obj
         /// Try to deserialize json to an object of type ^T
         [<MethodImplAttribute(MethodImplOptions.NoInlining)>]
         let inline tryDeserialize< ^T> json = S.tryDeserialize< ^T> json

--- a/FSharpLu.Json/WithFunctor.fs
+++ b/FSharpLu.Json/WithFunctor.fs
@@ -33,7 +33,9 @@ type With< ^S when ^S : (static member settings : JsonSerializerSettings)
         let serializer = JsonSerializer.Create(settings)
         serializer.Formatting <- formatting
         // Leave stream open after writing
-        use streamWriter = new System.IO.StreamWriter(stream, System.Text.UTF8Encoding.UTF8, 1024, true)
+        let DefaultStreamWriterEncoding = System.Text.UTF8Encoding.UTF8
+        let DefaultStreamWriterBufferSize = 1024
+        use streamWriter = new System.IO.StreamWriter(stream, DefaultStreamWriterEncoding, DefaultStreamWriterBufferSize, true)
         use jsonTextWriter = new JsonTextWriter(streamWriter)
         serializer.Serialize(jsonTextWriter, obj)
 

--- a/FSharpLu.Json/WithFunctor.fs
+++ b/FSharpLu.Json/WithFunctor.fs
@@ -32,7 +32,8 @@ type With< ^S when ^S : (static member settings : JsonSerializerSettings)
         let formatting = (^S:(static member formatting : Formatting)())
         let serializer = JsonSerializer.Create(settings)
         serializer.Formatting <- formatting
-        use streamWriter = new System.IO.StreamWriter(stream)
+        // Leave stream open after writing
+        use streamWriter = new System.IO.StreamWriter(stream, System.Text.UTF8Encoding.UTF8, 1024, true)
         use jsonTextWriter = new JsonTextWriter(streamWriter)
         serializer.Serialize(jsonTextWriter, obj)
 

--- a/FSharpLu.Json/WithFunctor.fs
+++ b/FSharpLu.Json/WithFunctor.fs
@@ -26,6 +26,16 @@ type With< ^S when ^S : (static member settings : JsonSerializerSettings)
         let json = JsonConvert.SerializeObject(obj, formatting, settings)
         System.IO.File.WriteAllText(file, json)
 
+    /// Serialize an object to Json with the specified converter and write the result to a stream
+    static member inline public serializeToStream (stream:System.IO.Stream) (obj:^T) =
+        let settings = (^S:(static member settings : JsonSerializerSettings)())
+        let formatting = (^S:(static member formatting : Formatting)())
+        let serializer = JsonSerializer.Create(settings)
+        serializer.Formatting <- formatting
+        use streamWriter = new System.IO.StreamWriter(stream)
+        use jsonTextWriter = new JsonTextWriter(streamWriter)
+        serializer.Serialize(jsonTextWriter, obj)
+
     /// Deserialize a Json to an object of type 'T
     static member inline public deserialize< ^T> json :^T =
         let settings = (^S:(static member settings :  JsonSerializerSettings)())


### PR DESCRIPTION
Fairly minor addition, but two questions:
- When adding `serializeToStream` to `BackwardCompatible.fs`, I stumbled across `serializeToFile`, which declares two parameters, but never uses them. This looks like point-free style was intended, but a copy-and-paste error kept the parameters. I fixed it here, is this correct?
- The added `serializeToStream` function takes a `System.IO.Stream` in analogy to the `deserializeStream` function. But is this the right type/abstraction? Intuitively, `System.IO.TextWriter` seems more useful.