### PR TITLE
Refactor and generalize the state machine-based `Queue Request Processor`

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,5 +2,6 @@
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <NUGET_PACKAGE_VERSION Condition=" '$(NUGET_PACKAGE_VERSION)' == '' ">0.666.666</NUGET_PACKAGE_VERSION>
+    <Deterministic>false</Deterministic>
   </PropertyGroup>
 </Project>

--- a/FSharpLu.Azure.Test/Azure.Test.Storage.fs
+++ b/FSharpLu.Azure.Test/Azure.Test.Storage.fs
@@ -137,8 +137,8 @@ type AzureStorageTests () =
     [<Fact(Skip="Needs Azure Storage key configuration")>]
     member x.``Azure Table implementation of Agent Storage interface is atomic``() =
         async {
-            let storageAccountName, storageAccountKey = 
-                failwithf "Please set azure storage account name and key"
+            let storageAccountConnectionString = 
+                failwithf "Please set azure storage account connectiong string before running this test"
             
             let tableName = "AgentJoinStorageTable"
 
@@ -148,13 +148,11 @@ type AzureStorageTests () =
                     timestamp = System.DateTimeOffset.UtcNow
                 }
 
-            let creds = Table.StorageCredentials(storageAccountName, storageAccountKey)
-            let uri = Table.StorageUri(System.Uri(sprintf "https://%s.table.core.windows.net" storageAccountName))
+            let storageAccount = Table.CloudStorageAccount.Parse(storageAccountConnectionString)
 
             let! storage =
                 AzureTableJoinStorage.newStorage
-                                        creds
-                                        uri
+                                        storageAccount
                                         tableName
                                         (System.TimeSpan.FromSeconds(1.0))
                                         (System.TimeSpan.FromSeconds(10.0))

--- a/FSharpLu.Azure.Test/FSharpLu.Azure.Test.fsproj
+++ b/FSharpLu.Azure.Test/FSharpLu.Azure.Test.fsproj
@@ -15,6 +15,7 @@
     <Compile Include="CommunicationTests.fs" />
     <Compile Include="Generators.fs" />
     <Compile Include="Azure.Test.Storage.fs" />
+    <Compile Include="QueueServiceHandlerTests.fs" />
     <Compile Include="Azure.Test.Queue.fs" />
   </ItemGroup>
   <ItemGroup>

--- a/FSharpLu.Azure.Test/QueueServiceHandlerTests.fs
+++ b/FSharpLu.Azure.Test/QueueServiceHandlerTests.fs
@@ -1,0 +1,297 @@
+﻿module Microsoft.FSharpLu.QueueServiceHandler.Test
+
+open Microsoft.FSharpLu.Logging
+open Microsoft.FSharpLu.StateMachineAgent
+open Microsoft.FSharpLu.StateMachineAgent.QueueScheduler
+open Microsoft.FSharpLu.StateMachineAgent.Agent
+open Xunit
+
+/// A request with input of type 'i and state 's
+type RequestOf<'i, 's> =
+    {
+        header :
+            {|
+                correlationId : string
+            |}
+        input : 'i
+        state : 's
+        metadata : RequestMetadata
+    }
+
+/// Context parameters passed to every request handler
+[<NoEquality;NoComparison>]
+type HandlerContext<'QueueMessage, 'Request> =
+    {
+        contextName : string
+        joinStore : Join.StorageInterface<'Request>
+        queue : QueueingAPI<'QueueMessage, 'Request>
+        queuedMessage : 'QueueMessage
+    }
+
+let createRequestContext<'QueueMessage, 'Request>
+    joinStore
+    (queue:QueueingAPI<'QueueMessage, 'Request>)
+    message
+    =
+    {
+        HandlerContext.contextName = "bla"
+        joinStore = joinStore
+        queue = queue
+        queuedMessage = message
+    }
+
+let toScheduler (c:HandlerContext<'QueueMessage, 'Request>) embed : Agent.Scheduler<_, _> =
+    {
+        spawn = c.queue.post
+        spawnIn = c.queue.postIn
+        persist = c.queue.update c.queuedMessage
+        embed = embed
+        joinStore = c.joinStore
+    }
+
+/// Wrapper for Agent.execute to be used in request handlers
+let inline run
+        title
+        (context: HandlerContext<'QueueMessage, ^Request>)
+        (request: RequestOf<'Input,'State>)
+        (embed: RequestMetadata -> 'State -> ^Request)
+        (transition: HandlerContext<'QueueMessage, ^Request> -> 'State -> Async<Transition<'State, 'Result, ^Request>>)
+    : Async<Agent.ExecutionInstruction< ^Request, _>>
+    =
+    Agent.execute request.state request.metadata {
+        Agent.title = title
+        logger = Microsoft.FSharpLu.Logging.TraceTags.info
+        tags = ["foo", "bar"]
+        transition = transition context
+        maximumExpectedStateTransitionTime = System.TimeSpan.FromMinutes(15.0)
+        maximumInprocessSleep = System.TimeSpan.FromMinutes(5.0)
+        scheduler = toScheduler context embed
+    }
+
+module Example =
+    type FiboStates =
+    | Start
+    | Calculate of int * int * int
+    | End of int
+
+    type FlipCoinStates =
+    | Start
+    | Flip
+    | End
+
+    /// All supported requests
+    type ServiceRequests =
+    | Fibo of RequestOf<{| i : int; requestQuota : int |}, FiboStates>
+    | FlipCoin of RequestOf<int, FlipCoinStates>
+    | Request3
+    | Shutdown
+
+    type ServiceQueues =
+        | ImportantQueue
+        | NotImportantQueue
+
+    let request1TestOutcome = System.Collections.Concurrent.ConcurrentDictionary<int, int>()
+
+    let request1Handler context request =
+        run "request1 handler" context request
+            (fun metadata newState -> ServiceRequests.Fibo({ request with state = newState; metadata = metadata }))
+            (fun context ->
+                function
+                | FiboStates.Start -> async {
+                    printfn "Received request"
+                    return Goto <| FiboStates.Calculate (request.input.i, 0, 1)
+                  }
+                | FiboStates.Calculate (i, fibminus_1, fib) ->  async {
+                    if i > 1 then
+                        return SleepAndGoto (System.TimeSpan.FromMilliseconds(10.0),
+                                                FiboStates.Calculate(i-1, fib, fibminus_1 + fib))
+                    else
+                        return Goto <| FiboStates.End (fib)
+                  }
+                | FiboStates.End (result) -> async {
+                    if not <| request1TestOutcome.TryAdd(request.input.i, result) then
+                        failwith "Result overwrite!"
+                    if request1TestOutcome.Count = request.input.requestQuota then
+                        do! context.queue.post ServiceRequests.Shutdown
+                    return Transition.Return (result)
+                  })
+
+    let request2Handler context request =
+        run "request2 handler" context request
+            (fun metadata newState -> ServiceRequests.FlipCoin({ request with state = newState; metadata = metadata }))
+            (fun context ->
+                function
+                | FlipCoinStates.Start -> async.Return <| Goto FlipCoinStates.Flip
+                | FlipCoinStates.Flip -> async {
+                    let r = System.Random(System.DateTime.UtcNow.Ticks |> int)
+                    if r.Next() % 2 = 0 then
+                        return Sleep <| System.TimeSpan.FromMilliseconds(10.0 * (float <| r.Next()))
+                    else
+                        return Goto <| FlipCoinStates.End
+                  }
+                | FlipCoinStates.End ->
+                    async.Return <| Transition.Return ()
+            )
+
+    let QueuesProcessingOptions =
+        {
+            SleepDurationWhenAllQueuesAreEmpty = System.TimeSpan.FromMilliseconds(10.0)
+            HeartBeatIntervals = System.TimeSpan.FromSeconds(1.0)
+            ConcurrentRequestWorkers = 10
+            WorkerReplacementTimeout = System.TimeSpan.FromHours(1.0)
+        }
+
+    let queuesHandlersOrderedByPriority<'QueueMessage> (cts:System.Threading.CancellationTokenSource)
+            :QueueProcessor<ServiceQueues,ServiceRequests,HandlerContext<'QueueMessage, ServiceRequests>> list =
+
+         let dispatch (c:HandlerContext<'QueueMessage, ServiceRequests>) (k:Continuation<ServiceRequests>) =
+              function
+              | ServiceRequests.Fibo r -> k.k (request1Handler c r)
+              | ServiceRequests.FlipCoin r -> k.k (request2Handler c r)
+              | ServiceRequests.Shutdown -> k.k (async {
+                                                      Trace.info "Shutdown request received"
+                                                      cts.Cancel()
+                                                      Trace.info "Token cancelled"
+                                                      return ExecutionInstruction.Completed None
+                                                })
+              | _ -> raise RejectedMessage
+
+         [
+            {
+                queueId = ServiceQueues.ImportantQueue
+                handler = dispatch
+                maxProcessTime = System.TimeSpan.FromMinutes(1.0)
+                messageBatchSize = 10
+            }
+            {
+                queueId = ServiceQueues.NotImportantQueue
+                handler = dispatch
+                maxProcessTime = System.TimeSpan.FromMinutes(1.0)
+                messageBatchSize = 32
+            }
+        ]
+
+module InMemorySchedulerTest =
+    open Example
+
+    let newInMemoryJoinStorage () : Agent.Join.StorageInterface<'m> =
+        let storage = System.Collections.Concurrent.ConcurrentDictionary<_, _>()
+        {
+            add = fun joinId joinEntry -> async {
+                        if not <| storage.TryAdd(joinId, joinEntry) then
+                            failwithf "Add: Failed to add %A" (joinId, joinEntry)
+                    }
+            update = fun joinId performEntryUpdate ->
+                        lock(storage) (fun () ->
+                            async {
+                                match storage.TryGetValue(joinId) with
+                                | true, entry ->
+                                    let newEntry = performEntryUpdate entry
+                                    storage.[joinId] <- newEntry
+                                    return newEntry
+                                | false, _ -> return failwithf "Update: Failed to retrieve data with id: %A" joinId
+                        }
+                    )
+            get = fun joinId ->
+                    async {
+                        match storage.TryGetValue(joinId) with
+                        | false, _ -> return failwithf "Get: There is no request with id : %A" joinId
+                        | true, entry -> return entry
+                    }
+
+        }
+
+    let joinStore = newInMemoryJoinStorage ()
+
+    let queueProcessLoop
+            (cts:System.Threading.CancellationTokenSource)
+            (queues:Map<Example.ServiceQueues,_>)=
+        async {
+            try
+                let context request = createRequestContext<System.Guid, Example.ServiceRequests> joinStore request
+                do! QueueScheduler.processingLoopMultipleQueues<Example.ServiceQueues, Example.ServiceRequests, _, System.Guid>
+                        Example.QueuesProcessingOptions
+                        (Example.queuesHandlersOrderedByPriority cts)
+                        (fun queueId -> Map.find queueId queues)
+                        context
+                        ignore // no heartbeat
+                        cts.Token
+                        (fun _ -> []) // no tags
+                        {new OutcomeLogger with member __.log _ = ()} // no logger
+            with
+            | QueueScheduler.ProcessingLoopCancelled ->
+                Trace.warning "Processing loop terminated by Azure."
+        }
+
+
+    [<Fact>]
+    let ``InMemoryScheduler Fibonnaci Test`` () =
+        async {
+            let importantQueue = InMemoryQueue.newQueue "inmemory" ImportantQueue
+            let nonImportantQueue = InMemoryQueue.newQueue "inmemory" NotImportantQueue
+            let queues =
+                [
+                    ImportantQueue, importantQueue
+                    NotImportantQueue, nonImportantQueue
+                ] |> Map.ofSeq
+
+            let shutdownSource = new System.Threading.CancellationTokenSource()
+
+            let fibonnaci = [|0;1;1;2;3;5;8;13;21;34;55;89;144|]
+
+            for i = 1 to fibonnaci.Length-1 do
+                let! req = Agent.createRequest joinStore
+                do! importantQueue.post
+                    <| ServiceRequests.Fibo(
+                        {
+                           header = {| correlationId = "Fibonnaci" |}
+                           input = {| i = i; requestQuota = fibonnaci.Length-1|}
+                           state = FiboStates.Start
+                           metadata = req
+                       })
+
+            do! queueProcessLoop shutdownSource queues
+
+            for kvp in request1TestOutcome do
+                let i = kvp.Key
+                Assert.Equal(request1TestOutcome.[i], fibonnaci.[i])
+
+        }
+
+module AzureQueueSchedulerTest =
+    open Microsoft.Azure.Cosmos
+    open Microsoft.Azure.Storage.Queue
+    open Microsoft.FSharpLu
+
+    let JoinTableName = "QueueServiceTest-AgentJoinStorageTable"
+    let QueueNamePrefix  = "QueueServiceTest"
+
+    let queueProcessLoop
+        (terminationRequested:System.Threading.CancellationToken)
+        (storageAccountConnectionString:string) =
+        async {
+            let! joinStore =
+                AzureTableJoinStorage.newStorage
+                                        (Table.CloudStorageAccount.Parse(storageAccountConnectionString))
+                                        JoinTableName
+                                        (System.TimeSpan.FromSeconds(1.0))
+                                        (System.TimeSpan.FromSeconds(10.0))
+                                        "testAgent"
+            let azureStorage = Azure.Context.getStorageAccountFromConnectionString storageAccountConnectionString
+            let context request = createRequestContext<CloudQueueMessage, Example.ServiceRequests> joinStore request
+            let shutdownSource = new System.Threading.CancellationTokenSource()
+            try
+                do! QueueScheduler.processingLoopMultipleQueues<Example.ServiceQueues, Example.ServiceRequests, _, CloudQueueMessage>
+                        Example.QueuesProcessingOptions
+                        (Example.queuesHandlersOrderedByPriority shutdownSource)
+                        (AzureQueue.newQueue azureStorage QueueNamePrefix)
+                        context
+                        ignore // no heartbeat
+                        terminationRequested
+                        (fun _ -> []) // no tags
+                        {new OutcomeLogger with member __.log _ = ()} // no logger
+            with
+            | QueueScheduler.ProcessingLoopCancelled ->
+                Trace.warning "Processing loop terminated by Azure."
+
+        }

--- a/FSharpLu.Azure/AzureQueueServiceHandler.fs
+++ b/FSharpLu.Azure/AzureQueueServiceHandler.fs
@@ -1,91 +1,131 @@
 ﻿// Copyright (c) Microsoft Corporation.
 namespace Microsoft.FSharpLu.StateMachineAgent
 
-/// A Request Service Processor where persistence is implemented using Azure Storage Queues
-module AzureQueue =
+/// A Request Processor with scheduling and persistence implemented using some queueing API
+module QueueScheduler =
 
-    open Microsoft.Azure.Storage.Queue
     open Microsoft.FSharpLu
-    open Microsoft.FSharpLu.Async
     open Microsoft.FSharpLu.Azure.AppInsights
     open Microsoft.FSharpLu.StateMachineAgent
 
-    /// Update content and increase visibility of an Azure Queue message
-    let update<'Q> (queue:CloudQueue) (queuedRequest:CloudQueueMessage) (m:'Q) visibility =
-        Microsoft.FSharpLu.Azure.Queue.updateMessage queue queuedRequest m visibility
-
-    /// Update visibility of an Azure Queue message and ensure it will be persisted at the end of the invisibility period.
-    /// Note: this may require to delete and re-post the same message to get around the Azure Queue message lifetime of 7 days.
-    let updateVisibility (queue:CloudQueue) (queuedRequest:CloudQueueMessage) visibilityTimeout =
-        async {
-            try
-                do! Microsoft.FSharpLu.Azure.Queue.increaseVisibilityTimeout queue queuedRequest visibilityTimeout
-            with
-            | e ->
-                TraceTags.error "Could not increase message visibility in Azure backend queue. Update errors are usually due to a request taking too long to process, causing the message visibility timeout to be reached, subsequently leading to two concurrent instances of the service to process the same request."
-                                [ "queuedMessage", queuedRequest.AsString
-                                  "exception", e.ToString()]
-        }
-
-    /// Delete a request from the queue
-    let delete (queue:CloudQueue) (queuedRequest:CloudQueueMessage) =
-        async {
-            try
-                do! queue.DeleteMessageAsync(queuedRequest) |> Async.AwaitTask
-            with
-            | e ->
-                TraceTags.error "Could not delete message from Azure backend queue. This is usually due to a request taking too long to process, causing the message visibility timeout to be reached, subsequently leading to two concurrent instances of the service to process the same request."
-                                    [ "queuedMessage", queuedRequest.AsString
-                                      "exception", e.ToString()]
-        }
-
-    /// Execute the specified action on the specified queued request
-    let executeAction (queue:CloudQueue) (queuedRequest:CloudQueueMessage) = function
-        | Agent.RequestAction.Delete ->
-            delete queue queuedRequest
-        | Agent.RequestAction.PostponeFor visibilityTimeout ->
-            updateVisibility queue queuedRequest visibilityTimeout
-        | Agent.RequestAction.PostponeAndReplace (newRequest, visibilityTimeout) ->
-            update queue queuedRequest newRequest visibilityTimeout
-
-    /// Implementation of agent operations using an Azure Queue
-    let inline toAgentOperations< ^T> queue =
+    /// Queue interface implemented by the underlying queueing infrastructure
+    /// (e.g. Azure Queue, mailbox processor, ConcurrentQueue, ...)
+    type QueueingAPI<'QueueMessage, 'QueueContent> =
         {
-            Agent.Operations.spawn = Microsoft.FSharpLu.Azure.Queue.postMessage< ^T> queue
-            Agent.Operations.spawnIn = Microsoft.FSharpLu.Azure.Queue.schedulePostMessage< ^T> queue
+            /// queue name
+            queueName : string
+            /// update content and visibility of a queue message
+            update : 'QueueMessage -> 'QueueContent -> System.TimeSpan -> Async<unit>
+            /// update visibility of a queue message
+            updateVisibility : 'QueueMessage -> System.TimeSpan -> Async<unit>
+            /// delete a queue message
+            delete : 'QueueMessage -> Async<unit>
+            /// serialize a queue message to string
+            serialize : 'QueueMessage -> string
+            /// deserialize a string to a queue message content
+            tryDeserialize : string -> Result<'QueueContent, string>
+            /// get queue message insertion time
+            insertionTime : 'QueueMessage -> System.DateTimeOffset
+            /// try to pop specified number of messages from the queue
+            tryGetMessageBatch : int -> System.TimeSpan -> Async<'QueueMessage list>
+            /// post a new message onto the queue
+            post : 'QueueContent -> Async<unit>
+            /// post a new message onto the queue with the specified visibility
+            postIn : 'QueueContent -> System.TimeSpan -> Async<unit>
         }
 
-    /// Handler for requests queued on an Azure Storage queue
-    /// 'R is the type of requests handled
-    /// 'C is a custom context parameter that will get passed to every request handler
-    type Handler<'C, 'R> = 'C -> 'R -> Async<Agent.RequestAction<'R>>
+    /// Info returned for a request successfully processed
+    /// 'Request is the type of request
+    /// 'Result is the request result type
+    /// 'QueueMessage type representing a queue message by the underlying queueing API
+    type ProcessedRequestInfo<'Request, 'Result, 'QueueMessage> =
+        {
+            /// status of the request execution
+            executionStatus : Agent.ExecutionInstruction<'Request,'Result>
+            /// the request, if it was properly parsed
+            request : 'Request
+            /// date/time when the request was posted on the queu
+            requestInsertionTime : System.DateTime
+            /// Time taken to process the request
+            processingTime : System.TimeSpan
+            /// queue message object from the underlying queue API
+            queuedMessage : 'QueueMessage
+        }
 
-    /// Defines a processor for request persisted on an Azure Storage Queue.
-    /// 'Q defines an enumeration of possible queue Ids
+    /// Info returned for a request that could not be processed
+    /// 'Request is the type of request
+    /// 'QueueMessage type representing a queue message by the underlying queueing API
+    type FailedRequestInfo<'Request, 'QueueMessage> =
+        {
+            /// A description of the error that occurred
+            errorMessage : string
+            /// More details about the error
+            details : string
+            /// processed request
+            request : 'Request option
+            /// date/time when the request was posted on the queu
+            requestInsertionTime : System.DateTime
+            /// Time taken to process the request
+            processingTime : System.TimeSpan
+            /// queue message object from the underlying queue API
+            queuedMessage : 'QueueMessage
+        }
+
+    /// Outcome of the processing of a request
+    /// 'Request is the type of request
+    /// 'Result is the request result type
+    /// 'QueueMessage type representing a queue message by the underlying queueing API
+    type RequestOutcome<'Request, 'Result, 'QueueMessage> =
+    | Processed of ProcessedRequestInfo<'Request, 'Result, 'QueueMessage>
+    | Error of FailedRequestInfo<'Request, 'QueueMessage>
+    | Rejected of FailedRequestInfo<'Request, 'QueueMessage>
+    | ExceptionThrown of System.Exception * FailedRequestInfo<'Request, 'QueueMessage>
+
+    /// A continuation that handles processing of an agent execution status.
+    /// Defining this as a class type rather than let-binding is a "trick"
+    /// to prevent the F# typecheker to unify the ghost generic type type parameter 'T
+    /// against the first occurrence of k.
+    /// This means that Continuation.k can be used in the same function
+    /// for different instances of the type parameter 'T.
+    type Continuation<'Request> =
+        abstract k<'Request, 'Result> : Async<Agent.ExecutionInstruction<'Request, 'Result>> -> Async<unit>
+
+    /// Loggger interface for request outcome
+    type OutcomeLogger =
+        abstract log : RequestOutcome<'Request, 'Result, 'QueueMessage> -> unit
+
+    /// Handler for queued requests
+    /// 'Request is the type of queued request
+    /// 'Context is a custom context parameter that will get passed to every request handler
+    type Handler<'Context, 'Request> = 'Context -> Continuation<'Request> -> 'Request -> Async<unit>
+
+    /// Defines a processor consuming queued request.
+    /// 'QId defines an enumeration of possible queue Ids
     /// 'R is the type of requests handled by the processor
     /// 'C is a custom context parameter that will get passed to every request handler
     [<NoEquality;NoComparison>]
-    type QueueProcessor<'Q, 'R, 'C> =
+    type QueueProcessor<'QId, 'Request, 'Context> =
         {
             /// Name of the queue
-            queueId : 'Q
+            queueId : 'QId
 
-            /// Function handling a request received on the Azure Queue
-            handler : Handler<'C, 'R>
+            /// Function handling a request received on a Queue
+            handler : Handler<'Context, 'Request>
 
             /// Initial value of the maximum expected processing time.
             ///
-            /// After this timeout expires Azure automatically reposts the message onto the queue.
+            /// Note for Azure queues: After this timeout expires Azure automatically reposts the message onto the queue.
             /// We want this value to be high enough to cover requests with long processing time (e.g. creating a VM in Azure)
             /// but not too high to avoid delays in case a real backend failure occurs.
             ///
-            /// Request handlers can dynamically override this value if more time is needed to process a request.
+            /// A request handler can dynamically override this value if more time is needed to process a request.
             /// State machine agents (QueueRequestHandling module) facilitate this by automatically updating the expected
             /// processing time on each transition of the state machine.
             maxProcessTime : System.TimeSpan
 
-            /// Number of messages to pull at once from the Azure queue
-            /// Keep this number low for maxium utilization of concurrency between worker role instances
+            /// Number of messages to pull at once from the a queue
+            ///
+            /// For Azure Queues, keep this number low for maxium utilization of concurrency between worker role instances
             /// Note: maximum allowed is 32 (if greater you'll get a warning followed by an obscure exception
             /// from Azure, See https://msdn.microsoft.com/en-us/library/azure/dd179474.aspx)
             messageBatchSize : int
@@ -106,116 +146,38 @@ module AzureQueue =
             WorkerReplacementTimeout : System.TimeSpan
         }
 
-    /// Attempt to retrieve one batch of message from the Azure queue
-    let tryGetMessageBatch (queue:CloudQueue) (processor:QueueProcessor<'Q, 'R, 'C>) =
-        async {
-            let visibilityTimeout = System.TimeSpan.FromSeconds(float processor.messageBatchSize * processor.maxProcessTime.TotalSeconds)
-                                    |> Microsoft.FSharpLu.Azure.Queue.softValidateVisibilityTimeout
-            let! messages = queue.GetMessagesAsync(processor.messageBatchSize, System.Nullable visibilityTimeout, null, null) |> Async.AwaitTask
-            return messages |> Seq.toList
-        }
-
-    /// Initialize the queue-based communication channel using the specified Azure Queue reference
-    let initChannel (queue:CloudQueue) =
-        async {
-            Trace.info "Monitoring queue %s" queue.Name
-            let! r = queue.CreateIfNotExistsAsync().AsAsync
-            if not r then
-                Trace.info "Queue %s was already created." queue.Name
-            return queue
-        }
-
-    /// Find pending request from the queue with highest priority
-    let rec private findHighestPriorityRequests queues =
-        async {
-            match queues with
-            | [] -> return None
-            | (queue, handling)::rest ->
-                let! m = tryGetMessageBatch queue handling
-                match m with
-                | [] -> return! findHighestPriorityRequests rest
-                | messages -> return Some (queue, handling, messages)
-        }
-
     /// Exception raised by message handlers when a message is rejected
     exception RejectedMessage
 
-    /// Info returned for a request successfully processed
-    type ProcessedRequestInfo<'R> =
-        {
-            /// agent action performed after processing the request
-            action : Agent.RequestAction<'R>
-            /// the request, if it was properly parsed
-            request : 'R
-            /// date/time when the request was posted on the queu
-            requestInsertionTime : System.DateTime
-            /// Time taken to process the request
-            processingTime : System.TimeSpan
-            /// queue message object from the Azure API
-            queuedMessage : CloudQueueMessage
-        }
-
-    /// Info returned for a request that could not be processed
-    type FailedRequestInfo<'R> =
-        {
-            /// A description of the error that occurred
-            errorMessage : string
-            /// More details about the error
-            details : string
-            /// agent action performed after processing the request
-            action : Agent.RequestAction<'R>
-            /// processed request
-            request : 'R option
-            /// date/time when the request was posted on the queu
-            requestInsertionTime : System.DateTime
-            /// Time taken to process the request
-            processingTime : System.TimeSpan
-            /// queue message object from the Azure API
-            queuedMessage : CloudQueueMessage
-        }
-
-    /// Outcome of the processing of a request
-    type RequestOutcome<'R> =
-    | Processed of ProcessedRequestInfo<'R>
-    | Error of FailedRequestInfo<'R>
-    | Rejected of FailedRequestInfo<'R>
-    | ExceptionThrown of System.Exception * FailedRequestInfo<'R>
-
-    /// Process a single request from an Azure Queue
-    let processMessage<'C,'R>
-            (context:'C)
-            (queue:CloudQueue)
-            (queuedMessage:CloudQueueMessage)
-            (tryDeserialize:string -> Async<Result<'R,string>>)
-            (handler:Handler<'C, 'R>)
-            (getTags:'R -> (string*string) list)
-            (logger: RequestOutcome<'R> -> unit) =
+    /// Process a single request from a Queue
+    let processRequest<'Context, 'Request, 'QueueMessage>
+            (context:'Context)
+            (queueSystem:QueueingAPI<'QueueMessage, 'Request>)
+            (queuedMessage:'QueueMessage)
+            (handler:Handler<'Context, 'Request>)
+            (getTags:'Request -> (string*string) list)
+            (logger: OutcomeLogger) =
         async {
 
             let requestInsertionTime =
-                // This gymnastic is needed to workAsync around spurious warning #52 from F# compiler in release mode.
-                // See http://stackoverflow.com/questions/13753312/warning-produced-by-f-value-has-been-copied-to-ensure-the-original-is-not-muta
-                let insertionTime = queuedMessage.InsertionTime |> (fun x -> x.GetValueOrDefault())
-                insertionTime.UtcDateTime
+                (queueSystem.insertionTime queuedMessage).UtcDateTime
 
-            let! parseResult = tryDeserialize queuedMessage.AsString
+            let queueMessageAsString = queueSystem.serialize queuedMessage
+            let parseResult = queueSystem.tryDeserialize queueMessageAsString
 
             match parseResult with
             | Result.Error deserializationError ->
-                let outcome =
+                logger.log <|
                     RequestOutcome.Error
                         {
                             errorMessage = "Could not parse queued message"
                             details = deserializationError
-                            action  = Agent.RequestAction.Delete
                             request = None
                             requestInsertionTime = requestInsertionTime
                             processingTime = System.TimeSpan.Zero
                             queuedMessage = queuedMessage
                         }
-                logger outcome
-                do! delete queue queuedMessage
-                return outcome
+                do! queueSystem.delete queuedMessage
 
             | Result.Ok parsedMessage ->
                 let tags = getTags parsedMessage
@@ -225,75 +187,82 @@ module AzureQueue =
                 let processingTime = System.Diagnostics.Stopwatch()
                 try
                     processingTime.Start()
-                    let! action = handler context parsedMessage
-                    processingTime.Stop()
 
-                    do! executeAction queue queuedMessage action
-                    let outcome =
-                        RequestOutcome.Processed
-                            {
-                                action  = action
-                                request = parsedMessage
-                                requestInsertionTime = requestInsertionTime
-                                processingTime = processingTime.Elapsed
-                                queuedMessage = queuedMessage
+                    do! handler context
+                            { new Continuation<'Request> with
+                              member __.k executionStatusAsync =
+                                async {
+                                    // Schedule the remaining execution of the specified queued request
+                                    let! executionStatus = executionStatusAsync
+                                    processingTime.Stop()
+                                    match executionStatus with
+                                    | Agent.ExecutionInstruction.Completed _ ->
+                                        do! queueSystem.delete queuedMessage
+                                    | Agent.ExecutionInstruction.SleepAndResume visibilityTimeout ->
+                                        do! queueSystem.updateVisibility queuedMessage visibilityTimeout
+                                    | Agent.ExecutionInstruction.SleepAndResumeAt (visibilityTimeout, newRequest) ->
+                                        do! queueSystem.update queuedMessage newRequest visibilityTimeout
+
+                                    logger.log <|
+                                        RequestOutcome.Processed
+                                            {
+                                                executionStatus = executionStatus
+                                                request = parsedMessage
+                                                requestInsertionTime = requestInsertionTime
+                                                processingTime = processingTime.Elapsed
+                                                queuedMessage = queuedMessage
+                                            }
+                                }
                             }
-
-                    logger outcome
-                    return outcome
+                            parsedMessage
                 with
                 | RejectedMessage ->
                     processingTime.Stop()
-                    let outcome =
+                    logger.log <|
                         RequestOutcome.Rejected
                             {
                                 errorMessage = "This request type was rejected from queue handler"
-                                details = sprintf "Queue name: %s" queue.Name
-                                action  = Agent.RequestAction.Delete
+                                details = sprintf "Queue name: %s" queueSystem.queueName
                                 request = Some parsedMessage
                                 requestInsertionTime = requestInsertionTime
                                 processingTime = processingTime.Elapsed
                                 queuedMessage = queuedMessage
                             }
-                    logger outcome
-                    do! delete queue queuedMessage
-                    return outcome
+                    do! queueSystem.delete queuedMessage
                 | e ->
                     processingTime.Stop()
                     let elapsed = processingTime.Elapsed
                     TraceTags.trackException e (tags @[
                                                   "postedTime", requestInsertionTime.ToString()
                                                   "processingTime", elapsed.ToString()
-                                                  "request", queuedMessage.AsString
+                                                  "request", queueMessageAsString
                                                 ])
 
-                    let outcome =
+                    logger.log <|
                         RequestOutcome.ExceptionThrown
                             (e,
                             {
                                 errorMessage = "Exception raised while processing request"
                                 details = sprintf "Exception: %O" e
-                                action  = Agent.RequestAction.Delete
                                 request = Some parsedMessage
                                 requestInsertionTime = requestInsertionTime
                                 processingTime = processingTime.Elapsed
                                 queuedMessage = queuedMessage
                             })
-                    do! delete queue queuedMessage
-                    return outcome
+                    do! queueSystem.delete queuedMessage
         }
 
     exception ProcessingLoopCancelled
 
-    /// A processing loop handling requests posted on multiple Azure Queues with
-    /// different assigned priorities
-    let processingLoopMultipleQueues<'Q, 'R, 'C>
+    /// A processing loop handling requests posted on multiple
+    /// queues with different assigned priorities
+    let processingLoopMultipleQueues<'QueueId, 'Request, 'Context, 'QueueMessage>
                 (options:Options)
-                (queuesOrderedByPriority:(CloudQueue * QueueProcessor<'Q, 'R, 'C>) list)
-                (createRequestContext : CloudQueue -> CloudQueueMessage -> 'C)
+                (queueProcessorsOrderedByPriority: (QueueProcessor<'QueueId, 'Request, 'Context>) list)
+                (getQueue:'QueueId -> QueueingAPI<_,_>)
+                (createRequestContext : QueueingAPI<_,_> -> 'QueueMessage -> 'Context)
                 (signalHeartBeat : unit -> unit)
-                (terminationRequested:System.Threading.CancellationToken)
-                (tryDeserialize:'C -> string -> Async<Result<'R, string>>)
+                (terminationRequested: System.Threading.CancellationToken)
                 getTags
                 logger
                 =
@@ -301,8 +270,20 @@ module AzureQueue =
             use processingPool = new Microsoft.FSharpLu.Async.Synchronization.Pool(options.ConcurrentRequestWorkers)
             let pool = processingPool :> Microsoft.FSharpLu.Async.Synchronization.IPool
 
+            /// Find pending request from the queue with highest priority
+            let rec findHighestPriorityRequests queues =
+                async {
+                    match queues with
+                    | [] -> return None
+                    | (queue, handling : QueueProcessor<'QueueId, 'Request, 'Context>)::rest ->
+                        let! m = queue.tryGetMessageBatch handling.messageBatchSize handling.maxProcessTime
+                        match m with
+                        | [] -> return! findHighestPriorityRequests rest
+                        | messages -> return Some (queue, handling, messages)
+                }
+
             /// Process a batch of messages
-            let processMessageBatch handler (queue:CloudQueue) (queueMessageBatch:CloudQueueMessage list) =
+            let processMessageBatch handler queue (queueMessageBatch:'QueueMessage list) =
                 Async.Parallel
                     [
                         for queuedMessage in queueMessageBatch ->
@@ -313,21 +294,26 @@ module AzureQueue =
                                 if terminationRequested.IsCancellationRequested then
                                     raise ProcessingLoopCancelled
                                 let context = createRequestContext queue queuedMessage
-                                let! outcome =
-                                    processMessage
+                                do! processRequest
                                         context
                                         queue
                                         queuedMessage
-                                        (tryDeserialize context)
                                         handler
                                         getTags
                                         logger
-                                return ()
                             }
                             |> Async.Catch // Individual request should be able to fail independently without taking down the entire batch
                     ]
                 |> Async.Ignore
 
+
+            let queuesOrderedByPriority =
+                queueProcessorsOrderedByPriority
+                |> Seq.map (fun handling ->
+                        let queue = getQueue handling.queueId
+                        Trace.info "Monitoring queue %s" queue.queueName
+                        queue, handling)
+                |> Seq.toList
 
             /// Outermost loop: process requests from each channel by priority
             /// Note: One drawback is that higher-priority queues may starve lower-priority ones
@@ -340,24 +326,204 @@ module AzureQueue =
 
                     if terminationRequested.IsCancellationRequested then
                         raise ProcessingLoopCancelled
+                    else
+                        let sleepDurationWhenAllQueuesAreEmptyInMs =
+                            options.SleepDurationWhenAllQueuesAreEmpty.TotalMilliseconds |> int
 
-                    let sleepDurationWhenAllQueuesAreEmptyInMs =
-                        options.SleepDurationWhenAllQueuesAreEmpty.TotalMilliseconds |> int
+                        let! highestRequest = findHighestPriorityRequests queuesOrderedByPriority
+                        match highestRequest with
+                        | None ->
+                            // all channels are empty: we rest for a bit
+                            do! Async.Sleep(sleepDurationWhenAllQueuesAreEmptyInMs)
 
-                    let! highestRequest = findHighestPriorityRequests queuesOrderedByPriority
-                    match highestRequest with
-                    | None ->
-                        // all channels are empty: we rest for a bit
-                        do! Async.Sleep(sleepDurationWhenAllQueuesAreEmptyInMs)
+                        | Some (queue, handling, firstMessageBatch) ->
+                            do! processMessageBatch handling.handler queue firstMessageBatch
 
-                    | Some (queue, handling, firstMessageBatch) ->
-                        do! processMessageBatch handling.handler queue firstMessageBatch
-
-                    return! processChannels heartBeatWatch
+                        return! processChannels heartBeatWatch
                 }
 
 
             let heartBeatWatch = System.Diagnostics.Stopwatch()
             heartBeatWatch.Start()
             do! processChannels heartBeatWatch
+        }
+
+    /// Deserialize a request
+    let inline tryDeserializeJson< ^Request> queuedMessageAsString =
+        match Microsoft.FSharpLu.Json.Compact.tryDeserialize< ^Request> queuedMessageAsString with
+        | Choice1Of2 message -> Result.Ok message
+        | Choice2Of2 error -> Result.Error error
+
+
+/// In-memory queue system implemented with System.Collections.ConcurrentQueue
+/// with not fault-tolerance (if the process crashes the queue content is lost)
+/// and not visiblity timeout when consuming messages
+module InMemoryQueue =
+    type QueueEntry< ^QueueContent> =
+        {
+            insertionTime : System.DateTimeOffset
+            content : ^QueueContent
+            visible : bool
+        }
+
+    /// Create an instance of an queue processor based on mailbox processor
+    let inline newQueue<'QueueId, ^QueueContent> queueNamePrefix (queueId:'QueueId)
+           : QueueScheduler.QueueingAPI<System.Guid, ^QueueContent> =
+        let queueName = sprintf "%s-%A" queueNamePrefix queueId
+        let queue = new System.Collections.Concurrent.ConcurrentDictionary<System.Guid, QueueEntry< ^QueueContent>>()
+        {
+            queueName = queueName
+
+            update = fun queuedRequest queueContent visibility -> async {
+                    let newContent =
+                        queue.AddOrUpdate(
+                                queuedRequest,
+                                (fun _ -> { insertionTime = System.DateTimeOffset.UtcNow
+                                            content = queueContent
+                                            visible = true }),
+                                (fun _ c -> { c with content = queueContent }))
+                    return ()
+                }
+
+            // no-op: visiblity timeout is infinite in this implementation
+            updateVisibility = fun queuedRequest visibilityTimeout -> async.Return ()
+
+            delete = fun queuedRequest -> async {
+                    let success, _ = queue.TryRemove(queuedRequest)
+                    if not success then
+                        failwith "could not remove entry from queue"
+                }
+
+            insertionTime = fun queueMessage ->
+                let success, message = queue.TryGetValue(queueMessage)
+                if not success then
+                    failwith "could not find queue entry"
+                message.insertionTime
+
+            serialize = fun queueMessage ->
+                let success, message = queue.TryGetValue(queueMessage)
+                if not success then
+                    failwith "could not find queue entry"
+                Microsoft.FSharpLu.Json.Compact.serialize message.content
+
+            tryDeserialize = QueueScheduler.tryDeserializeJson< ^QueueContent>
+
+            tryGetMessageBatch = fun batchSize _  -> async {
+                    let nextBatch =
+                        lock queue (fun () ->
+                            queue :> seq<_>
+                            |> Seq.where (fun m -> m.Value.visible)
+                            |> Seq.sortBy (fun m -> m.Value.insertionTime)
+                            |> Seq.map (fun c ->
+                                if not <| queue.TryUpdate(c.Key, { c.Value with visible = false }, c.Value) then
+                                    failwith "impossible: queue entry disappeard!"
+                                c.Key
+                            )
+                            |> Seq.truncate batchSize
+                            |> Seq.toList
+                        )
+                    Microsoft.FSharpLu.Logging.Trace.info "Batch: %A" nextBatch
+                    return nextBatch
+                }
+
+            post = fun (content:^QueueContent) -> async {
+                    let id = System.Guid.NewGuid()
+                    let queueEntry =
+                        { insertionTime = System.DateTimeOffset.UtcNow
+                          content = content
+                          visible = true
+                        }
+                    if not <| queue.TryAdd(id, queueEntry) then
+                        failwith "impossible: guid collision"
+            }
+
+            postIn = fun (content:^QueueContent) delay -> async {
+                    let id = System.Guid.NewGuid()
+                    let queueEntry =
+                        { insertionTime = System.DateTimeOffset.UtcNow
+                          content = content
+                          visible = true
+                        }
+                    let child = async {
+                        do! Async.Sleep (int <| delay.TotalMilliseconds)
+                        if not <| queue.TryAdd(id, queueEntry) then
+                            failwith "impossible: guid collision"
+                    }
+                    let r = Async.StartChild child
+                    return ()
+            }
+        }
+
+/// Queue system implemented with Azure Queues
+module AzureQueue =
+
+    open Microsoft.Azure.Storage.Queue
+    open QueueScheduler
+    open Microsoft.FSharpLu.Azure.Queue
+    open Microsoft.FSharpLu.Logging
+    open Microsoft.Azure.Storage
+
+    type ProcessedRequestInfo<'Request, 'Result> = ProcessedRequestInfo<'Request, 'Result, CloudQueueMessage>
+    type FailedRequestInfo<'Request> =  FailedRequestInfo<'Request, CloudQueueMessage>
+
+    /// Create an instance of an queue processor based on Azure Queue
+    let inline newQueue<'QueueId, ^QueueContent> (azureStorage:CloudStorageAccount) queueNamePrefix (queueId:'QueueId)
+        : QueueScheduler.QueueingAPI<CloudQueueMessage, ^QueueContent> =
+        // Create the reference to the Azure queue
+        let queueClient = azureStorage.CreateCloudQueueClient()
+        let queueName = sprintf "%s-%A" queueNamePrefix queueId
+        let queue = queueClient.GetQueueReference(queueName)
+        if not <| queue.CreateIfNotExists() then
+            Trace.info "Queue %s was already created." queueName
+        {
+            queueName = queueName
+
+            // Update content and increase visibility of an Azure Queue message
+            update = fun queuedRequest content visibility -> updateMessage queue queuedRequest content visibility
+
+            // Update visibility of an Azure Queue message and ensure it will be persisted at the end of the invisibility period.
+            // Note: this may require to delete and re-post the same message to get around the Azure Queue message lifetime of 7 days.
+            updateVisibility = fun queuedRequest visibilityTimeout ->
+                async {
+                    try
+                        do! increaseVisibilityTimeout queue queuedRequest visibilityTimeout
+                    with
+                    | e ->
+                        TraceTags.error "Could not increase message visibility in Azure backend queue. Update errors are usually due to a request taking too long to process, causing the message visibility timeout to be reached, subsequently leading to two concurrent instances of the service to process the same request."
+                                        [ "queuedMessage", queuedRequest.AsString
+                                          "exception", e.ToString()]
+                }
+
+            // Delete a request from the queue
+            delete = fun queuedRequest ->
+                async {
+                    try
+                        do! queue.DeleteMessageAsync(queuedRequest) |> Async.AwaitTask
+                    with
+                    | e ->
+                        TraceTags.error "Could not delete message from Azure backend queue. This is usually due to a request taking too long to process, causing the message visibility timeout to be reached, subsequently leading to two concurrent instances of the service to process the same request."
+                                            [ "queuedMessage", queuedRequest.AsString
+                                              "exception", e.ToString()]
+                }
+
+            insertionTime = fun queueMessage -> queueMessage.InsertionTime.GetValueOrDefault()
+
+            serialize = fun queueMessage -> queueMessage.AsString
+
+            tryDeserialize = QueueScheduler.tryDeserializeJson
+
+            // Attempt to retrieve one batch of message from the Azure queue
+            tryGetMessageBatch = fun messageBatchSize maxProcessTime ->
+                async {
+                    let visibilityTimeout =
+                        System.TimeSpan.FromSeconds(float messageBatchSize * maxProcessTime.TotalSeconds)
+                        |> Microsoft.FSharpLu.Azure.Queue.softValidateVisibilityTimeout
+                    let! messages = queue.GetMessagesAsync(messageBatchSize, System.Nullable visibilityTimeout, null, null) |> Async.AwaitTask
+                    return messages |> Seq.toList
+                }
+
+            post = fun request -> Microsoft.FSharpLu.Azure.Queue.postMessage queue request
+
+            postIn = fun request -> Microsoft.FSharpLu.Azure.Queue.schedulePostMessage queue request
+
         }

--- a/FSharpLu.Azure/AzureTableAgentJoinStorage.fs
+++ b/FSharpLu.Azure/AzureTableAgentJoinStorage.fs
@@ -15,15 +15,14 @@ module AzureTableJoinStorage =
     /// Instantiate an implementation of Agent.Join.StorageInterface
     /// backed up by an Azure Table
     let newStorage
-            (credentials: Table.StorageCredentials)
-            (uri: Table.StorageUri)
+            (storage: Table.CloudStorageAccount)
             (tableName: string)
             (retryInterval: System.TimeSpan)
             (totalTimeout: System.TimeSpan)
             (agentId: string) /// Customer identifier that gets recorded in every entry in Azure Table
         : Async<Agent.Join.StorageInterface<'m>> =
         async {
-            let tableClient = Table.CloudTableClient(uri, credentials)
+            let tableClient = Table.CloudTableClient(storage.TableStorageUri, storage.Credentials)
             let table = tableClient.GetTableReference(tableName)
             let! _ = table.CreateIfNotExistsAsync() |> Async.AwaitTask
 

--- a/FSharpLu.sln
+++ b/FSharpLu.sln
@@ -13,6 +13,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		.gitignore = .gitignore
 		appveyor.yml = appveyor.yml
 		CI-vsts.yml = CI-vsts.yml
+		Directory.Build.props = Directory.Build.props
 		fsharplu-nuget.md = fsharplu-nuget.md
 		fsharplu.json-nuget.md = fsharplu.json-nuget.md
 		FSharpLu.Json.md = FSharpLu.Json.md


### PR DESCRIPTION
- Split concepts of Agent, Scheduler and Queuing interface
- Rename RequestAction to ExecutionInstruction
- Add in-memory based implementation of Queuing API
- Add Azure Queue-based implementation of Queuing API
- Add Fibonnaci in-memory test for QueueServiceHandler