### PR TITLE
Azure Queue unit tests fixes

### DIFF
--- a/FSharpLu.Azure/AzureQueueScheduler.fs
+++ b/FSharpLu.Azure/AzureQueueScheduler.fs
@@ -5,44 +5,95 @@
 module Microsoft.FSharpLu.Actor.QueueScheduler.AzureQueue
 
 open Microsoft.Azure.Storage.Queue
-open Microsoft.FSharpLu.Azure.Queue
 open Microsoft.FSharpLu.Logging
 open Microsoft.Azure.Storage
 open Microsoft.FSharpLu.Actor.ServiceRequests
+open Microsoft.FSharpLu.Azure.Queue
+open Microsoft.FSharpLu.Async
 
 type ProcessedRequestInfo<'Request, 'Result> = ProcessedRequestInfo<'Request, 'Result, CloudQueueMessage>
 type FailedRequestInfo<'Request> =  FailedRequestInfo<'Request, CloudQueueMessage>
 
 /// Create an instance of an queue processor based on Azure Queue
-let inline newQueue<'QueueId, ^QueueContent> (azureStorage:CloudStorageAccount) queueNamePrefix (queueId:'QueueId)
-    : QueueingAPI<CloudQueueMessage, ^QueueContent> =
+/// `clear` - true to clear the queue content if it already exists
+type AzureQueueScheduler<'QueueId, 'QueueContent> (azureStorage:CloudStorageAccount, queueNamePrefix, queueId:'QueueId, ?clear) =
+
+    let clear = Option.defaultValue false clear
+
     // Create the reference to the Azure queue
     let queueClient = azureStorage.CreateCloudQueueClient()
-    let queueName = (queueNamePrefix + "-" + sprintf "%A" queueId).ToLowerInvariant()
-    let queue = queueClient.GetQueueReference(queueName)
-    if not <| queue.CreateIfNotExists() then
-        Trace.info "Queue %s was already created." queueName
-    {
-        queueName = queueName
+    let theQueueName = (queueNamePrefix + "-" + sprintf "%A" queueId).ToLowerInvariant()
+    let queue = 
+        let q = queueClient.GetQueueReference(theQueueName)
+        if not <| q.CreateIfNotExists() then
+            Trace.info "Queue %s was already created." theQueueName
+        if clear then
+            q.Clear()
+        q
+    
+    member __.AzureQueue with get () = queue
+    
+    /// Serialize an object to Json with the specified converter
+    static member inline serialize (object:'T) :string =
+        Newtonsoft.Json.JsonConvert.SerializeObject(object, Microsoft.FSharpLu.Json.Compact.TupleAsArraySettings.formatting, Microsoft.FSharpLu.Json.Compact.TupleAsArraySettings.settings) 
+        
+    /// Deserialize a Json to an object of type 'T
+    static member inline tryDeserialize<'T> json : Result< ^T, System.Exception> =
+        try
+            let o = Newtonsoft.Json.JsonConvert.DeserializeObject< ^T>(json, Microsoft.FSharpLu.Json.Compact.TupleAsArraySettings.settings) 
+            if obj.ReferenceEquals(o, null) then
+                Result.Error <| (Newtonsoft.Json.JsonReaderException("Json deserialization returned null") :> System.Exception)
+            else
+                Result.Ok o
+        with
+        | :? Newtonsoft.Json.JsonReaderException
+        | :? Newtonsoft.Json.JsonSerializationException as exn ->
+            Result.Error <| exn
+        | exn ->
+            Result.Error <| (Newtonsoft.Json.JsonReaderException("Exception while deserializing stream: %O", exn) :> System.Exception)
+
+
+    interface IQueueingAPI<CloudQueueMessage, 'QueueContent> with
+        member __.queueName = theQueueName
+
+        member __.tryGetContent queuedRequest =
+            AzureQueueScheduler<_,_>.tryDeserialize<'QueueContent> queuedRequest.AsString            
+        
+        member __.post request =
+            async {
+                let json = AzureQueueScheduler<_,_>.serialize<'QueueContent> request
+                let message = CloudQueueMessage(json)
+                return! queue.AddMessageAsync(message).AsAsync
+            }
+
+        member __.postIn request t =
+            Microsoft.FSharpLu.Azure.Queue.schedulePostMessage< ^QueueContent> queue request t
 
         // Update content and increase visibility of an Azure Queue message
-        update = fun queuedRequest content visibility -> updateMessage queue queuedRequest content visibility
+        member __.update queuedRequest content visibility =
+            Microsoft.FSharpLu.Azure.Queue.updateMessage queue queuedRequest content visibility
 
         // Update visibility of an Azure Queue message and ensure it will be persisted at the end of the invisibility period.
         // Note: this may require to delete and re-post the same message to get around the Azure Queue message lifetime of 7 days.
-        updateVisibility = fun queuedRequest visibilityTimeout ->
+        member __.updateVisibility queuedRequest visibilityTimeout =
             async {
                 try
                     do! increaseVisibilityTimeout queue queuedRequest visibilityTimeout
                 with
                 | e ->
                     TraceTags.error "Could not increase message visibility in Azure backend queue. Update errors are usually due to a request taking too long to process, causing the message visibility timeout to be reached, subsequently leading to two concurrent instances of the service to process the same request."
-                                    [ "queuedMessage", queuedRequest.AsString
-                                      "exception", e.ToString()]
-            }
+                                        [ "queuedMessage", queuedRequest.AsString
+                                          "exception", e.ToString()
+                                          "visibilityTimeout", visibilityTimeout.ToString()
+                                          "nextVisibileTime", queuedRequest.NextVisibleTime.GetValueOrDefault().ToString()
+                                          "nowInUtc", System.DateTime.UtcNow.ToString()
+                                          "expiryDate", queuedRequest.ExpirationTime.ToString()
+                                          "id", queuedRequest.Id
+                                          "popreceipt", queuedRequest.PopReceipt.ToString()]
+           }
 
         // Delete a request from the queue
-        delete = fun queuedRequest ->
+        member __.delete queuedRequest =
             async {
                 try
                     do! queue.DeleteMessageAsync(queuedRequest) |> Async.AwaitTask
@@ -53,30 +104,20 @@ let inline newQueue<'QueueId, ^QueueContent> (azureStorage:CloudStorageAccount) 
                                           "exception", e.ToString()]
             }
 
-        insertionTime = fun queueMessage -> queueMessage.InsertionTime.GetValueOrDefault()
+        member __.insertionTime queuedRequest = queuedRequest.InsertionTime.GetValueOrDefault()
 
-        prettyPrintQueueMessage = fun queueMessage -> queueMessage.AsString
+        member __.prettyPrintQueueMessage queuedRequest = queuedRequest.AsString
 
-        tryGetContent = fun queueMessage ->
-                match Microsoft.FSharpLu.Json.Compact.tryDeserialize< ^QueueContent> queueMessage.AsString with
-                | Choice1Of2 message -> Result.Ok message
-                | Choice2Of2 error -> Result.Error error
 
         // Attempt to retrieve one batch of message from the Azure queue
-        tryGetMessageBatch = fun messageBatchSize maxProcessTime ->
+        member __.tryGetMessageBatch messageBatchSize maxProcessTime =
             async {
                 let visibilityTimeout =
                     System.TimeSpan.FromSeconds(float messageBatchSize * maxProcessTime.TotalSeconds)
                     |> Microsoft.FSharpLu.Azure.Queue.softValidateVisibilityTimeout
                 let! messages = queue.GetMessagesAsync(messageBatchSize, System.Nullable visibilityTimeout, null, null) |> Async.AwaitTask
                 return messages |> Seq.toList
-            }
-
-        post = fun request -> Microsoft.FSharpLu.Azure.Queue.postMessage queue request
-
-        postIn = fun request -> Microsoft.FSharpLu.Azure.Queue.schedulePostMessage queue request
-
-    }
+            }    
 
 /// A scheduler factory based on Azure Queue queueing system
 type AzureQueueSchedulerFactory<'Header, 'Request, 'CustomContext>

--- a/FSharpLu.Json/WithFunctor.fs
+++ b/FSharpLu.Json/WithFunctor.fs
@@ -39,13 +39,13 @@ type With< ^S when ^S : (static member settings : JsonSerializerSettings)
         use jsonTextWriter = new JsonTextWriter(streamWriter)
         serializer.Serialize(jsonTextWriter, obj)
 
-    /// Deserialize a Json to an object of type 'T
+    /// Deserialize a Json to an object of statically-resolved type ^T
     static member inline public deserialize< ^T> json :^T =
         let settings = (^S:(static member settings :  JsonSerializerSettings)())
         let formatting = (^S:(static member formatting : Formatting)())
         JsonConvert.DeserializeObject< ^T>(json, settings)
 
-    /// Deserialize a stream to an object of type 'T
+    /// Deserialize a stream to an object of statically-resolved type ^T
     static member inline public deserializeStream< ^T> (stream:System.IO.Stream) =
         let settings = (^S:(static member settings :  JsonSerializerSettings)())
         let serializer = JsonSerializer.Create(settings)
@@ -53,21 +53,21 @@ type With< ^S when ^S : (static member settings : JsonSerializerSettings)
         use jsonTextReader = new JsonTextReader(streamReader)
         serializer.Deserialize< ^T>(jsonTextReader)
 
-    /// Read Json from a file and desrialized it to an object of type ^T
+    /// Read Json from a file and desrialized it to an object statically-resolved type ^T
     static member inline deserializeFile< ^T> file :^T =
         System.IO.File.ReadAllText file |> With< ^S>.deserialize
 
-    /// Try to deserialize a stream to an object of type ^T
+    /// Try to deserialize a stream to an object statically-resolved type ^T
     static member inline tryDeserializeStream< ^T> stream =
         Helpers.tryCatchJsonSerializationException< ^T, System.IO.Stream> false (With< ^S>.deserializeStream) stream
         |> Helpers.exceptionToString
 
-    /// Try to deserialize json to an object of type ^T
+    /// Try to deserialize json to an object ostatically-resolved type ^T
     static member inline tryDeserialize< ^T> json =
         Helpers.tryCatchJsonSerializationException< ^T, string> false (With< ^S>.deserialize) json
         |> Helpers.exceptionToString
 
-    /// Try to read Json from a file and desrialized it to an object of type 'T
+    /// Try to read Json from a file and desrialized it to an object statically-resolved type ^T
     static member inline tryDeserializeFile< ^T> file =
         Helpers.tryCatchJsonSerializationException< ^T, string> false (With< ^S>.deserializeFile) file
         |> Helpers.exceptionToString

--- a/FSharpLu.Tests/HofstadterCallTest.fs
+++ b/FSharpLu.Tests/HofstadterCallTest.fs
@@ -120,7 +120,7 @@ let transition<'QueueMessage> (operations:Operations<'QueueMessage, Header, Mess
         return Transition.Return result
       }
 
-let startTest (queue:Map<Gender,QueueingAPI<_, Envelope<Header,Message>>>) =
+let startTest (queue:Map<Gender, IQueueingAPI<_, Envelope<Header,Message>>>) =
     async {
         let n = expected.[Gender.Female].Length-1
         do! queue.[Gender.Female].post { 
@@ -145,8 +145,8 @@ let ``Hofstadter sequence - mutually recursive calls`` () =
     async {
 
         let agentQueues = 
-            [ yield Gender.Female, InMemoryQueue.newQueue<int,Envelope<Header, Message>> "Hofstadter-female" 0
-              yield Gender.Male, InMemoryQueue.newQueue<int,Envelope<Header, Message>> "Hofstadter-male" 1
+            [ yield Gender.Female, InMemoryQueue.InMemoryQueueProcessor<int,Envelope<Header, Message>>("Hofstadter-female", 0) :> IQueueingAPI<_,_>
+              yield Gender.Male, InMemoryQueue.InMemoryQueueProcessor<int,Envelope<Header, Message>>("Hofstadter-male", 1) :> IQueueingAPI<_,_>
             ] |> Map.ofSeq
                     
         let shutdownSource = new System.Threading.CancellationTokenSource()

--- a/FSharpLu/ServiceRequest.fs
+++ b/FSharpLu/ServiceRequest.fs
@@ -140,7 +140,7 @@ type Envelope<'Header, 'Request> =
 type Operations<'QueueMessage, 'Header, 'Request>
     (
         /// The queue scheduling system
-        queue:QueueingAPI<'QueueMessage,Envelope<'Header,'Request>>,
+        queue:IQueueingAPI<'QueueMessage,Envelope<'Header,'Request>>,
 
         /// The envelope of the current request being processed by the handler
         envelope:Envelope<'Header,'Request>
@@ -169,7 +169,7 @@ type Operations<'QueueMessage, 'Header, 'Request>
 type QueueingContext<'QueueMessage, 'Header, 'Request, 'CustomContext> =
     {
         /// the underlying queing system.
-        queue : QueueingAPI<'QueueMessage, Envelope<'Header, 'Request>>
+        queue : IQueueingAPI<'QueueMessage, Envelope<'Header, 'Request>>
         /// the message that has just been dequeued and need to be processed
         queuedMessage : 'QueueMessage
         /// the storage system used to record join/fork points


### PR DESCRIPTION
- Clear queue before running azure queue test
- validate and adjust granularity of azure visibility timeout (milliseconds not supported)
- Replace QueueingAPI record by IQueueingAPI interface
- Parameterized Fibonacci test with concurrent dictionary used to store request results, (to prevent interference between Azure and inmemory test)